### PR TITLE
Quick Fix for Forrests' Damage Popup System

### DIFF
--- a/ServerExt/Classes/KFExtendedHUD.uc
+++ b/ServerExt/Classes/KFExtendedHUD.uc
@@ -26,7 +26,7 @@ var transient array<FKillMessageType> KillMessages;
 var int HealthBarFullVisDist, HealthBarCutoffDist;
 var transient float BestPetXL, BestPetYL;
 
-struct DamageInfo
+struct PopupDamageInfo
 {
     var int Damage;
     var float HitTime;
@@ -36,7 +36,7 @@ struct DamageInfo
     var color FontColor;
 };
 const DAMAGEPOPUP_COUNT = 32;
-var DamageInfo DamagePopups[32];
+var PopupDamageInfo DamagePopups[32];
 var int NextDamagePopupIndex;
 var float DamagePopupFadeOutTime;
 


### PR DESCRIPTION
The name "DamageInfo" made HMB have compiling issues, the fix I found was to rename it to something else. Ex. PopupDamageInfo